### PR TITLE
For MacOS build, dir should be /build/buildtools/macosx64

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -3,20 +3,20 @@ Build Streembit
 
 The Streembit Core software is a Node.js application which uses the NW.js(node-webkit) library. NW.js is an app runtime based on Chromium. In order to build Streembit from source you must be familiar with Node.js, the Chromium project and NW.js (node-webkit).
 
-To build Streembit from source first you must build Chromium software and the NW.js (node-webkit) library. 
+To build Streembit from source first you must build Chromium software and the NW.js (node-webkit) library.
 
 To build Chromium please refer to the Chromium project web site.
 
 [Build summary](https://www.chromium.org/nativeclient/how-tos/build-tcb)
- 
+
 [Get the Chromium code](http://www.chromium.org/developers/how-tos/get-the-code)
- 
+
 [Windows build instructions](https://chromium.googlesource.com/chromium/src/+/master/docs/windows_build_instructions.md)
 
 To build NW.js please refer to the NW.js [build documentation](http://docs.nwjs.io/en/latest/For%20Developers/Building%20NW.js/).
 
 
-Run Streembit from source 
+Run Streembit from source
 ------------------------
 
 Once Chromium and NW.js are built clone the streembit repository:  
@@ -34,7 +34,7 @@ $ npm install
 
 Run Streembit:  
 ```bash
-$ /path/to/nw . 
+$ /path/to/nw .
 ```
 (The node-webkit executables must be in the /nw directory if you run the above command. The package.json file must exists in the Streembit directory).
 
@@ -54,7 +54,7 @@ Build node-webkit from source or download the latest Linux 64-bit node-webkit bi
 Execute the build/build_linux64.sh file from the Linux terminal.
 
 MacOS build:  
-Build node-webkit from source or download the latest MAC OS X node-webkit binaries from the node-webkit project site, and copy it to the /build/buildtools/macosx directory.   
+Build node-webkit from source or download the latest MAC OS X node-webkit binaries from the node-webkit project site, and copy it to the /build/buildtools/macosx64 directory.   
 Execute the build/build_macosx64.sh file from the terminal.
 
 
@@ -63,4 +63,3 @@ Build the streembitseed application
 -----------------------------------
 
 To help and contribute to the stability of Streembit network please run the streemo-seed application. More seeds make the network more stable and having more seeds deployed we can mitigate DDoS attacks and government interventions more effectively.  Also, if you wish to run your own Streembit network you must run your own streembitseed nodes. streembitseed is a Node.js application based on the streembitlib library, but without the Chromium/NW.js UI components. To build streembit-seed from source clone the [streembitseed source](https://github.com/streembit/streembitseed.git) and follow the instructions of to the readme.
-


### PR DESCRIPTION
Modified the documentation for mac osx builds.